### PR TITLE
Changed addin to avoid duplicate entries in python system path

### DIFF
--- a/fusion_idea_addin.py
+++ b/fusion_idea_addin.py
@@ -312,7 +312,8 @@ class RunScriptEventHandler(adsk.core.CustomEventHandler):
                 logger.warning("No script provided and debugging not requested. There's nothing to do.")
                 return
 
-            sys.path.append(pydevd_path)
+            if pydevd_path not in sys.path:
+                sys.path.append(pydevd_path)
             try:
                 if debug:
                     sys.path.append(os.path.join(pydevd_path, "pydevd_attach_to_process"))


### PR DESCRIPTION
After starting a script several times I recognized that the python system path was extended by pydevd_path each time the script was run. 

This update introduces a check before appending to the system path to ensure no duplicate entries are added. This modification prevents the unnecessary cluttering of the system path with the same paths multiple times.